### PR TITLE
Ensure {#close} created Trello cards land at top of destination list

### DIFF
--- a/.github/workflows/trello-move-attach-assign.yml
+++ b/.github/workflows/trello-move-attach-assign.yml
@@ -157,6 +157,7 @@ jobs:
             form.set('name', name);
             form.set('desc', desc || '');
             form.set('idList', idList);
+            form.set('pos', 'top');
             if (idMembers && idMembers.length) form.set('idMembers', idMembers.join(','));
             const res = await fetch(`${base}/cards?${auth}`, { method: 'POST', body: form });
             if (!res.ok) throw new Error(`Create failed: ${res.status} ${res.statusText} ${await res.text()}`);


### PR DESCRIPTION
## Summary
- Add `pos: top` when creating Trello cards so {#close <list>} places new cards at the top of the target list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a455c9d058832588f4e8573a6a7e00