### PR TITLE
Process Trello tags only from merge commit

### DIFF
--- a/.github/workflows/trello-move-attach-assign.yml
+++ b/.github/workflows/trello-move-attach-assign.yml
@@ -37,7 +37,12 @@ jobs:
           }
 
           const event = JSON.parse(fs.readFileSync(GITHUB_EVENT_PATH, 'utf8'));
-          const commits = event.commits || [];
+          const ref = event.ref || '';
+          const branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+          const isMerge = Array.isArray(event.head_commit?.parents) && event.head_commit.parents.length > 1;
+          const commits = (isMerge && (branch === 'development' || branch === 'master'))
+            ? [event.head_commit]
+            : (event.commits || []);
           const repoHtml = event.repository?.html_url || '';
 
           // Matches: {#close <card_id> <list_name>}, {#close <card_id>}, {#close <list_name>}, or {#close}


### PR DESCRIPTION
## Summary
- Limit Trello automation to inspect only the merge commit when merging into development or master.

## Testing
- `node -e "const event={ref:'refs/heads/development',head_commit:{parents:[1,2],id:'merge',message:'Merge'},commits:[{id:'a',message:'{#close 1}'}]}; const ref=event.ref||''; const branch=ref.startsWith('refs/heads/')?ref.slice('refs/heads/'.length):ref; const isMerge=Array.isArray(event.head_commit?.parents)&&event.head_commit.parents.length>1; const commits=(isMerge&&(branch==='development'||branch==='master'))?[event.head_commit]:(event.commits||[]); console.log(commits.map(c=>c.id));"`
- `node -e "const event={ref:'refs/heads/development',head_commit:{parents:[1],id:'b'},commits:[{id:'a'},{id:'b'}]}; const ref=event.ref||''; const branch=ref.startsWith('refs/heads/')?ref.slice('refs/heads/'.length):ref; const isMerge=Array.isArray(event.head_commit?.parents)&&event.head_commit.parents.length>1; const commits=(isMerge&&(branch==='development'||branch==='master'))?[event.head_commit]:(event.commits||[]); console.log(commits.map(c=>c.id));"`
- `node -e "const event={ref:'refs/heads/master',head_commit:{parents:[1,2],id:'merge',message:'Merge'},commits:[{id:'a',message:'{#close 1}'}]}; const ref=event.ref||''; const branch=ref.startsWith('refs/heads/')?ref.slice('refs/heads/'.length):ref; const isMerge=Array.isArray(event.head_commit?.parents)&&event.head_commit.parents.length>1; const commits=(isMerge&&(branch==='development'||branch==='master'))?[event.head_commit]:(event.commits||[]); console.log(commits.map(c=>c.id));"`

------
https://chatgpt.com/codex/tasks/task_e_68ad896287fc8325a3a0ec5317a08088