### PR TITLE
Use Trello idShort when referencing Trello cards

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -106,13 +106,13 @@ jobs:
           const cardsUrl = new URL(`https://api.trello.com/1/boards/${TRELLO_BOARD_ID}/cards/open`);
           cardsUrl.searchParams.set('key', TRELLO_KEY);
           cardsUrl.searchParams.set('token', TRELLO_TOKEN);
-          cardsUrl.searchParams.set('fields', 'id,name,idList,shortLink');
+          cardsUrl.searchParams.set('fields', 'id,name,idList,idShort');
 
           const appendOutput = (card) => {
-            if (!card || !card.shortLink) {
-              throw new Error('Unable to determine Trello card shortLink.');
+            if (!card || typeof card.idShort === 'undefined') {
+              throw new Error('Unable to determine Trello card idShort.');
             }
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `card-id=${card.shortLink}\n`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `card-id=${card.idShort}\n`);
           };
 
           const trelloFetch = async (input, init) => {

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -83,13 +83,13 @@ jobs:
           const cardsUrl = new URL(`https://api.trello.com/1/boards/${TRELLO_BOARD_ID}/cards/open`);
           cardsUrl.searchParams.set('key', TRELLO_KEY);
           cardsUrl.searchParams.set('token', TRELLO_TOKEN);
-          cardsUrl.searchParams.set('fields', 'id,name,idList,shortLink');
+          cardsUrl.searchParams.set('fields', 'id,name,idList,idShort');
 
           const appendOutput = (card) => {
-            if (!card || !card.shortLink) {
-              throw new Error('Unable to determine Trello card shortLink.');
+            if (!card || typeof card.idShort === 'undefined') {
+              throw new Error('Unable to determine Trello card idShort.');
             }
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, `card-id=${card.shortLink}\n`);
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `card-id=${card.idShort}\n`);
           };
 
           const trelloFetch = async (input, init) => {


### PR DESCRIPTION
## Summary
- request the Trello card `idShort` in the manual release and version bump workflows
- propagate the `idShort` output so commits and tags reference the numeric identifier

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914b515d6348325891f5eb27e67b187)